### PR TITLE
 Improve getsenv

### DIFF
--- a/docs/Scripts/getsenv.md
+++ b/docs/Scripts/getsenv.md
@@ -2,14 +2,14 @@
 
 !!! warning "Only works on active scripts"
 
-    This function will throw an error if the script is not actively running or if it's running on a different Luau VM - such as an [Actor](https://create.roblox.com/docs/reference/engine/classes/Actor).
+    This function will throw an error if the script isn't currently running. If the script is running but on a different Lua State (such as on an [Actor](https://create.roblox.com/docs/reference/engine/classes/Actor)), the function will return nil instead.
 
 `#!luau getsenv` returns the **global environment table** of a given [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), or [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript).
 
 This environment contains **all global variables, functions** available to the target script, such as custom-defined functions or state values.
 
 ```luau
-function getsenv(script: BaseScript | ModuleScript): { [any]: any }
+function getsenv(script: BaseScript | ModuleScript): { [any]: any } | nil
 ```
 
 ## Parameters


### PR DESCRIPTION
Modified getsenv to return nil instead of throwing an error if the script is running but on another LVM (like Actor), also updated function signature to match this.

Change will be enforced once senS updates sUNC (cmon stop being lazy)