### PR TITLE
Clarify reasons for not supporting upvalues on C closures

### DIFF
--- a/docs/Debug/getupvalue.md
+++ b/docs/Debug/getupvalue.md
@@ -2,7 +2,7 @@
 
 !!! warning "C closures are not supported"
     
-    This function will throw an error if called on a C closure, such as [`#!luau print`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#print), since C closures do not expose upvalues.
+    This function will throw an error if called on a C closure, such as [`#!luau print`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#print), for security reasons.
 
 `#!luau debug.getupvalue` returns the upvalue at the specified index from a Luau function's closure. If the index is invalid or out of bounds, an error will occur.
 

--- a/docs/Debug/getupvalues.md
+++ b/docs/Debug/getupvalues.md
@@ -2,7 +2,7 @@
 
 !!! warning "C closures are not supported"
     
-    This function will throw an error if called on a C closure, such as [`#!luau print`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#print), since C closures do not expose upvalues.
+    This function will throw an error if called on a C closure, such as [`#!luau print`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#print), for security reasons.
 
 `#!luau debug.getupvalues` returns a list of upvalues captured by a Luau function. These are the external variables that a function closes over from its surrounding scope.
 

--- a/docs/Debug/setupvalue.md
+++ b/docs/Debug/setupvalue.md
@@ -2,7 +2,7 @@
 
 !!! warning "C closures not supported"
     
-    This function will throw an error if called on a C closure, such as [`#!luau print`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#print), since C closures do not expose upvalues.
+    This function will throw an error if called on a C closure, such as [`#!luau print`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#print), for security reasons.
 
 `#!luau debug.setupvalue` replaces an upvalue at the specified index in a Luau function, with a new value.
 


### PR DESCRIPTION
C closures do have upvalues, however modifying them could lead to bad vulnerabilities.
I have changed the reason from "do not expose upvalues" to "for security reasons".