### PR TITLE
Add script to docs homepage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,22 @@ Whether you're an executor developer, a curious tester, or a contributor helping
 - [How to Contribute](./About/contributing.md)
 
 Thank you for being here.
+
+
+---
+
+## 🏃 The script
+Before diving into the in-depth documentation for sUNC, it is important to become acquainted with the test itself by running it yourself to understand *which* functions sUNC evaluates.
+
+```luau title="The sUNC testing script" linenums="1"
+getgenv().sUNCDebug = {
+    ["printcheckpoints"] = false,
+    ["delaybetweentests"] = 0
+}
+
+loadstring(game:HttpGet("https://script.sunc.su/"))() -- (1)
+```
+
+1. This loadstring uses https://script.sunc.su/, which is an official mirror of the sUNC script. If the mirror is down or you would like to use the original loadstring, visit [this raw link](https://gitlab.com/sens3/nebunu/-/raw/main/HummingBird8's_sUNC_yes_i_moved_to_gitlab_because_my_github_acc_got_brickedd/sUNCm0m3n7.lua).
+
+Please note that as of sUNC v2.0, the test now only runs inside of the official testing game. The latest one may be retrieved from [our Discord server](https://discord.gg/FNNfTUpFYv).


### PR DESCRIPTION
Added the script to the homepage of the documentation.
Additionally added the alternative link as a code annotation, in case the mirror is unavailable or a user does not want to use it.

The comment inside of the code (`-- (1)`) and the number after the code (`1. This loadstring uses...`) are part of the code annotations feature of the internal documentation platform. The comment, when actually rendered, will appear as a clickable plus icon which gives more information.

![Screenshot 2025-04-14 at 03 13 19](https://github.com/user-attachments/assets/8e4a99d0-8476-4581-9628-7fd169ae159c)
