### PR TITLE
Add compareinstances & Instances library grammar revision

### DIFF
--- a/docs/Instances/README.md
+++ b/docs/Instances/README.md
@@ -12,6 +12,7 @@ With the Instances library, you can:
 
 - **List all objects** tracked by the client using [`#!luau getinstances`](./getinstances.md)
 - **List nil-parented objects** using [`#!luau getnilinstances`](./getnilinstances.md)
+- **Compare two objects** using [`#!luau compareinstances`](./compareinstances.md)
 - **Safely clone instance references** using [`#!luau cloneref`](./cloneref.md)
 - **Access hidden UI containers** using [`#!luau gethui`](./gethui.md)
 - **Inspect function-based properties** with [`#!luau getcallbackvalue`](./getcallbackvalue.md)

--- a/docs/Instances/compareinstances.md
+++ b/docs/Instances/compareinstances.md
@@ -1,0 +1,27 @@
+# `compareinstances`
+
+`#!luau compareinstances` checks if two [`#!luau Instances`](https://create.roblox.com/docs/reference/engine/classes/Instance) are equal.
+
+This is primarily used for instanced which have been [`#!luau cloneref`](./cloneref.md)'d, where the normal equality check with `#!luau ==` fails.
+
+```luau
+function compareinstances(object1: Instance, object2: Instance): boolean
+```
+
+## Parameters
+
+| Parameter | Description                      |
+|-----------|----------------------------------|
+| `#!luau object1`  | This first [`#!luau Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance) to compare. |
+| `#!luau object2` | The second [`#!luau Instances`](https://create.roblox.com/docs/reference/engine/classes/Instance) to compare against. |
+
+---
+
+## Example
+
+```luau title="Comparing instances" linenums="1"
+print(compareinstances(game, game))              -- true
+print(compareinstances(game, workspace))         -- false
+print(compareinstances(game, cloneref(game)))    -- true
+print(game == cloneref(game))                    -- false
+```

--- a/docs/Scripts/getloadedmodules.md
+++ b/docs/Scripts/getloadedmodules.md
@@ -5,7 +5,7 @@
     This function **only** returns [`ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances that have already been loaded using [`#!luau require`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#require).  
     It does **not** return all [`ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) objects in the game - for that, use [`#!luau getscripts`](./getscripts.md).
 
-`#!luau getloadedmodules` returns a list of all [`ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances that have been **loaded** (e.g. [`#!luau require`'d](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#require)).
+`#!luau getloadedmodules` returns a list of all [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances that have been **loaded** (e.g. [`#!luau require`'d](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#require)).
 
 This includes only modules with completed executions, and **excludes** any modules that errored or haven't been required yet.
 

--- a/docs/Scripts/getrunningscripts.md
+++ b/docs/Scripts/getrunningscripts.md
@@ -1,6 +1,6 @@
 # `getrunningscripts`
 
-`#!luau getrunningscripts` returns a list of **all running scripts** in the caller's global state. This includes [`Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), and [`ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances - excluding [CoreScripts](https://robloxapi.github.io/ref/class/CoreScript.html) by default.
+`#!luau getrunningscripts` returns a list of **all running scripts** in the caller's global state. This includes [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), and [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances - excluding [`#!luau CoreScripts`](https://robloxapi.github.io/ref/class/CoreScript.html) by default.
 
 ```luau
 function getrunningscripts(): { BaseScript | ModuleScript }

--- a/docs/Scripts/getscriptbytecode.md
+++ b/docs/Scripts/getscriptbytecode.md
@@ -4,7 +4,7 @@
 
     This function should return `#!luau nil` if the script has no bytecode. This makes it easier to check for absence consistently across executors.
 
-`#!luau getscriptbytecode` retrieves the bytecode of a [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript), and [`Script`](https://create.roblox.com/docs/reference/engine/classes/Script).
+`#!luau getscriptbytecode` retrieves the bytecode of a [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript), and [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script).
 
 
 ```luau

--- a/docs/Scripts/getscripts.md
+++ b/docs/Scripts/getscripts.md
@@ -1,8 +1,8 @@
 # `getscripts`
 
-`#!luau getscripts` returns a list of **all [`Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), and [`ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances** present.
+`#!luau getscripts` returns a list of **all [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), and [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instances** present.
 
-This function excludes [CoreScripts](https://robloxapi.github.io/ref/class/CoreScript.html) by default.
+This function excludes [`#!luau CoreScripts`](https://robloxapi.github.io/ref/class/CoreScript.html) by default.
 
 ```luau
 function getscripts(): { BaseScript | ModuleScript }

--- a/docs/Scripts/getsenv.md
+++ b/docs/Scripts/getsenv.md
@@ -6,7 +6,7 @@
 
 `#!luau getsenv` returns the **global environment table** of a given [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), or [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript).
 
-This environment contains **all global variables, functions** available to the target script, such as custom-defined functions or state values.
+This environment contains **all global variables and functions** available to the target script, such as custom-defined functions or state values.
 
 ```luau
 function getsenv(script: BaseScript | ModuleScript): { [any]: any } | nil

--- a/docs/Scripts/loadstring.md
+++ b/docs/Scripts/loadstring.md
@@ -2,11 +2,13 @@
 
 !!! warning "Unsafe by design"
 
-    Compiles the given string, and returns it runnable in a function. The environment must become unsafe after this function is called due to it allowing the modification of globals uncontrollably (see [setfenv](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#setfenv)/[getfenv](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#getfenv) documentation).
+    Compiles the given string, and returns it runnable in a function. The environment must become unsafe after this function is called due to it allowing the modification of globals uncontrollably (see [`#!luau setfenv`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#setfenv)/[`#!luau getfenv`](https://create.roblox.com/docs/reference/engine/globals/LuaGlobals#getfenv) documentation).
 
-!!! info "Notes on `loadstring`"
+!!! info "Should error when compilation fails"
 
-    If the source compiles sucecssfully, you will get a runnable function that, when called, will execute the source you provided along with the passed arguments. If the source fails to compile, you will instead receive `#!luau nil` alongside the error, explaining what went wrong.
+    This function should return `#!luau nil` and an error message if the provided code fails to compile.
+
+Compiles a string of Luau code and returns it as a runnable function. If the code has errors, `#!luau nil` is returned and an error message is output.
 
 ```luau
 function loadstring<A...>(source: string, chunkname: string?): (((A...) -> any) | nil, string?)
@@ -14,10 +16,10 @@ function loadstring<A...>(source: string, chunkname: string?): (((A...) -> any) 
 
 ## Parameters
 
-| Parameter         | Description                                                                 |
-|-------------------|-----------------------------------------------------------------------------|
-| `#!luau source`        | The source code string to compile.                                           |
-| `#!luau chunkname?`    | Custom chunk name. |
+| Parameter           | Description                        |
+|---------------------|------------------------------------|
+| `#!luau source`     | The source code string to compile. |
+| `#!luau chunkname?` | Custom chunk name.                 |
 
 ---
 


### PR DESCRIPTION
- Wrote `compareinstances`
- Fixed grammar in entire Instances library
- Added description (or rather moved) in loadstring, as for some reason it was crammed into a note instead of regular text. Moved it from the note back to the proper description
- Added Luau syntax highlighting to many code snippets where it was missing