### PR TITLE
Improved `getsenv` and `getscripts` function signatures and descriptions

### DIFF
--- a/docs/Scripts/getscripts.md
+++ b/docs/Scripts/getscripts.md
@@ -5,7 +5,7 @@
 This function excludes [`#!luau CoreScripts`](https://robloxapi.github.io/ref/class/CoreScript.html) by default.
 
 ```luau
-function getscripts(): { BaseScript | ModuleScript }
+function getscripts(): { Script | LocalScript | ModuleScript }
 ```
 
 ## Parameters

--- a/docs/Scripts/getsenv.md
+++ b/docs/Scripts/getsenv.md
@@ -2,14 +2,14 @@
 
 !!! warning "Only works on active scripts"
 
-    This function will throw an error if the script isn't currently running. If the script is running but on a different Lua State (such as on an [Actor](https://create.roblox.com/docs/reference/engine/classes/Actor)), the function will return nil instead.
+    This function will throw an error if the script is not currently running. If the script is running but on a different Lua State (such as on an [Actor](https://create.roblox.com/docs/reference/engine/classes/Actor)), the function will return nil instead.
 
 `#!luau getsenv` returns the **global environment table** of a given [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), or [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript).
 
 This environment contains **all global variables and functions** available to the target script, such as custom-defined functions or state values.
 
 ```luau
-function getsenv(script: BaseScript | ModuleScript): { [any]: any } | nil
+function getsenv(script: Script | LocalScript | ModuleScript): { [any]: any }?
 ```
 
 ## Parameters


### PR DESCRIPTION
- Updated `getscripts` return type to use explicit script types.
- Improved `getsenv` function using precise types and optional return (`?`)
- Tweaked warning wording for clarity

- Pmo hawk tuah (PLEASE JUST ACCEPT ONE PR RICHY)