### PR TITLE
Getscripthash wording

### DIFF
--- a/docs/Scripts/getscripthash.md
+++ b/docs/Scripts/getscripthash.md
@@ -5,7 +5,7 @@
     The hash must be computed **on the encrypted, compressed bytecode** - not after any modification.  
     This function should also return `#!luau nil` if the script has no bytecode.
 
-`#!luau getscripthash` returns a ***hexadecimal format*** [SHA-384 hash](https://en.wikipedia.org/wiki/SHA-3) of the raw bytecode for a given [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), or [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript).
+`#!luau getscripthash` returns a [SHA-384 hash](https://en.wikipedia.org/wiki/SHA-3) in ***hexadecimal format*** of the raw bytecode for a given [`#!luau Script`](https://create.roblox.com/docs/reference/engine/classes/Script), [`#!luau LocalScript`](https://create.roblox.com/docs/reference/engine/classes/LocalScript), or [`#!luau ModuleScript`](https://create.roblox.com/docs/reference/engine/classes/ModuleScript).
 
 This is useful for **identifying scripts** by their content, especially when checking for known modules or verifying integrity.
 
@@ -17,7 +17,7 @@ function getscripthash(script: BaseScript | ModuleScript): string | nil
 
 | Parameter      | Description                                            |
 |----------------|--------------------------------------------------------|
-| `#!luau script` | The script instance to hash.                           |
+| `#!luau script` | The [BaseScript](https://create.roblox.com/docs/reference/engine/classes/BaseScript) or [ModuleScript](https://create.roblox.com/docs/reference/engine/classes/ModuleScript) instance to hash.                           |
 
 ---
 


### PR DESCRIPTION
Placed wording of hex format in the preferable and natural sounding place

Also changed « script » in parameters section to BaseScript and ModuleScript with links