### PR TITLE
Small improvements

### DIFF
--- a/docs/Instances/firetouchinterest.md
+++ b/docs/Instances/firetouchinterest.md
@@ -16,13 +16,15 @@ function firetouchinterest(part1: BasePart, part2: BasePart, toggle: boolean | n
 |----------------|----------------------------------------------------------------------------------------------|
 | `#!luau part1`   | The initiating [`#!luau BasePart`](https://create.roblox.com/docs/reference/engine/classes/BasePart). |
 | `#!luau part2`   | The [`#!luau BasePart`](https://create.roblox.com/docs/reference/engine/classes/BasePart) that should be touched.            |
-| `#!luau toggle`  | Whether to simulate touch start or end. `#!luau false` or `#!luau 0` simulates touch; `#!luau true` or `#!luau 1` simulates un-touch. |
+| `#!luau toggle`  | Whether to simulate touch start or end. `#!luau true` or `#!luau 0` simulates touch; `#!luau false` or `#!luau 1` simulates un-touch. |
 
 ---
 
-## Example
+## Examples
 
-```luau title="Simulating a Touched event using firetouchinterest" linenums="1"
+### Example 1
+
+```luau title="Simulating a Touched event using 'true/false'" linenums="1"
 local dummy_part = Instance.new("Part")
 dummy_part.CFrame = CFrame.new(0, -200, 0)
 dummy_part.Anchored = true
@@ -34,7 +36,25 @@ end)
 
 local player_head = game.Players.LocalPlayer.Character.Head
 
-firetouchinterest(player_head, dummy_part, false) -- Simulate touch
+firetouchinterest(player_head, dummy_part, true) -- Simulate touch
 task.wait(0.5)
-firetouchinterest(player_head, dummy_part, true) -- Simulate un-touch
+firetouchinterest(player_head, dummy_part, false) -- Simulate un-touch
+```
+### Example 2
+
+```luau title="Simulating a Touched event using '0/1'" linenums="1"
+local dummy_part = Instance.new("Part")
+dummy_part.CFrame = CFrame.new(0, -200, 0)
+dummy_part.Anchored = true
+dummy_part.Parent = workspace
+
+dummy_part.Touched:Connect(function(part)
+    print(part.Name .. " touched the dummy part!")
+end)
+
+local player_head = game.Players.LocalPlayer.Character.Head
+
+firetouchinterest(player_head, dummy_part, 0) -- Simulate touch
+task.wait(0.5)
+firetouchinterest(player_head, dummy_part, 1) -- Simulate un-touch
 ```

--- a/docs/Instances/getcallbackvalue.md
+++ b/docs/Instances/getcallbackvalue.md
@@ -5,7 +5,7 @@
 Normally, these properties are **write-only**, meaning you can assign a function to them but cannot read them back. This function bypasses that limitation and exposes the function directly.
 
 ```luau
-function getcallbackvalue(object: Instance, property: string): (...any) -> (...any) | nil
+function getcallbackvalue(object: Instance, property: string): any | nil
 ```
 
 ## Parameters

--- a/docs/Instances/gethui.md
+++ b/docs/Instances/gethui.md
@@ -3,7 +3,7 @@
 `#!luau gethui` returns a **hidden [`#!luau Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance)** container used for safely storing UI elements. This container is mainly designed to **avoid detections**.
 
 ```luau
-function gethui(): BasePlayerGui | Folder
+function gethui(): LayerCollector | Folder
 ```
 
 ## Parameters

--- a/docs/Instances/gethui.md
+++ b/docs/Instances/gethui.md
@@ -3,7 +3,7 @@
 `#!luau gethui` returns a **hidden [`#!luau Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance)** container used for safely storing UI elements. This container is mainly designed to **avoid detections**.
 
 ```luau
-function gethui(): LayerCollector | Folder
+function gethui(): BasePlayerGui | Folder
 ```
 
 ## Parameters


### PR DESCRIPTION
firetouchinterest:

-> Fix docs example showing wrong usage.
-> Make another example to show how 0/1 is used, not just true/false

getcallbackvalue:

-> Modify the return value to be `any`, since getcallbackvalue should be able to return every callback value property assigned to it, not just functions.