### PR TITLE
Parser update +1 other

### DIFF
--- a/docs/About/test-results.md
+++ b/docs/About/test-results.md
@@ -8,7 +8,7 @@ sUNC is known for its strict tests. Ever since it was made, it was built to expo
 
 As of **sUNC V2**, all tests must be conducted in the official sUNC testing game. This game may be found in our [Discord server](https://discord.gg/FNNfTUpFYv).
 
-We chose to do so, because by having a dedicated server, we're able to provide you with the new sUNC Rubis test results. This allows us to provide you with verified and reproducible results, instead of people sending meaningless screenshots of their console output.
+We chose to do so, because by having a dedicated server, we're able to provide you with the new online test results via Rubiš. This allows us to provide you with verified and reproducible results, instead of people sending meaningless screenshots of their console output.
 
 ---
 

--- a/docs/Instances/firetouchinterest.md
+++ b/docs/Instances/firetouchinterest.md
@@ -40,6 +40,7 @@ firetouchinterest(player_head, dummy_part, true) -- Simulate touch
 task.wait(0.5)
 firetouchinterest(player_head, dummy_part, false) -- Simulate un-touch
 ```
+
 ### Example 2
 
 ```luau title="Simulating a Touched event using '0/1'" linenums="1"

--- a/docs/Signals/README.md
+++ b/docs/Signals/README.md
@@ -22,4 +22,4 @@ With the Signals library, you can:
 - **Fire** a signal's Luau connections using [`#!luau firesignal`](./firesignal.md).
 - **Replicate signals to the server** with [`#!luau replicatesignal`](./replicatesignal.md), if supported by the signal.
 
-For a list of known replicable signals, click [this](https://rubis.app/view/?scrap=AIOzG1Di7NSLADKE).
+For a list of known replicable signals, click [this](https://rubis.app/markdown-focus/?scrap=AIOzG1Di7NSLADKE&accent=a460f9).

--- a/parser/docExtractor.lua
+++ b/parser/docExtractor.lua
@@ -1,7 +1,10 @@
+local insert = table.insert
+local concat = table.concat
+
 return function(markdown)
     local lines = {}
     for line in markdown:gmatch("[^\r\n]+") do
-        table.insert(lines, line)
+        insert(lines, line)
     end
 
     local result = {
@@ -16,6 +19,10 @@ return function(markdown)
     local codeblockLanguage = nil
     local insideAdmonition = false
     local descriptionCaptured = false
+
+    -- this is incredibly naive - look into writing a full lexer-ish/parser for the extractor instead later
+    local sigCaptured = false
+    local signature = {}
 
     for i = 1, #lines do
         local line = lines[i]
@@ -35,19 +42,27 @@ return function(markdown)
             current = "parameters"
         elseif line:match("^```") then
             if not insideCodeblock then
+                -- open code block
                 insideCodeblock = true
                 codeblockLanguage = line:match("^```(%w+)")
             else
+                -- closing code block
                 insideCodeblock = false
                 codeblockLanguage = nil
+                sigCaptured = true
             end
         elseif line:match("^# ") and current == "header" then
             result.title = line:match("^#%s+`(.-)`") or line:match("^#%s+(.-)$")
         elseif current == "header" and not descriptionCaptured and line:match("%S") then
             result.description = line
             descriptionCaptured = true
-        elseif insideCodeblock and codeblockLanguage == "luau" and not result.signature then
-            result.signature = line
+        elseif insideCodeblock and codeblockLanguage == "luau" and not sigCaptured then
+            insert(signature, line)
+            -- if not result.signature then
+            --     result.signature = line
+            -- else
+            --     result.signature = result.signature .. "\n" .. line
+            -- end
         elseif current == "parameters" and line:match("|") then
             local param, desc = line:match("|%s*`.-luau%s+(.-)`%s*|%s*(.-)%s*|")
             if param and desc then
@@ -57,6 +72,8 @@ return function(markdown)
 
         ::continue::
     end
+
+    result.signature = concat(signature, "\n")
 
     return result
 end

--- a/parser/indexExtractor.lua
+++ b/parser/indexExtractor.lua
@@ -1,7 +1,10 @@
+local insert = table.insert
+local concat = table.concat
+
 return function(markdown)
     local lines = {}
     for line in markdown:gmatch("[^\r\n]+") do
-        table.insert(lines, line)
+        insert(lines, line)
     end
 
     local constructed = {}
@@ -47,9 +50,9 @@ return function(markdown)
             if line:match("^%-%-%-$") or line:match("^## ") then
                 break
             end
-            table.insert(constructed, line)
+            insert(constructed, line)
         end
     end
 
-    return table.concat(constructed, "\n")
+    return concat(constructed, "\n")
 end

--- a/parser/main.lua
+++ b/parser/main.lua
@@ -48,10 +48,17 @@ end
 
 --[[
 functions to be cautious of (due to unique doc format) when parsing:
+
+request
+filtergc
+getgc
+
+Signals/Connection
 WebSocket library
-Connection object under Signals lib
-request() function
-filtergc()
+
+remove things like annotations, e.g. "-- (1)" or maybe even parse them?!
+
+Drawing lib functions except dont count readme
 
 uhh more i forgor
 ]]

--- a/parser/package.lua
+++ b/parser/package.lua
@@ -8,8 +8,8 @@ return {
     author = { name = "Richard Ziupsnys", email = "hello@richy.lol" },
     homepage = "https://github.com/sUNC-Utilities/docs.sunc.su/tree/main/parser",
     dependencies = {
-        "luvit/json",
-        "creationix/coro-fs"
+        "luvit/fs",
+        "luvit/json"
     },
     files = {
         "!*"


### PR DESCRIPTION
THis PR has 3 commits, the first one is simply an automatic formatting applied to all markdown files where applicable (with no text content changed) - in this case it is only 1 file where there was no line between a heading.

The second commit fixes the ambiguity in the wording of test results, before it was "sUNC Rubis test results..." but now it is "online test results via Rubiš" - a clear separation of concerns (because Rubiš and sUNC are two separate and distinct entities, sUNC is not a product of Rubiš and vice versa)

The third commit is the actual fix for our parser to support the multiline function signatures that are present in functions such as `getgc` and `request`. Support for `filtergc` parsing will probably be added later since its an entire directory that needs to be parsed individually. The fix was just to keep scanning until we encountered the end of a markdown code block and then add a simple guard to ensure we never scan more than one code block in the document. Also changed the project to stop reying on creationix's coro-fs library and moved to Luvit's native `fs`.