### PR TITLE
Parser fix + `built-info` deprecation

### DIFF
--- a/parser/docExtractor.lua
+++ b/parser/docExtractor.lua
@@ -31,7 +31,8 @@ return function(markdown)
             insideAdmonition = true
             goto continue
         elseif insideAdmonition then
-            if line:match("^%s*$") or not line:match("^%s") then
+            -- fixed: non-indented non-blank line should end the admonition
+            if not line:match("^%s") and line:match("%S") then
                 insideAdmonition = false
             else
                 goto continue

--- a/parser/main.lua
+++ b/parser/main.lua
@@ -113,7 +113,6 @@ fs.mkdirpSync("../docs/built-info") -- old directory, now deprecated
 fs.mkdirpSync("../docs/api")
 
 local bot_json = json.encode(bot, { indent = true })
-fs.writeFileSync("../docs/built-info/bot.json", bot_json) -- old
 fs.writeFileSync("../docs/api/jumbo.json", bot_json)
 
 local viewer = {}
@@ -129,6 +128,7 @@ end
 viewer[""] = nil
 
 local viewer_json = json.encode(viewer, { indent = true })
+-- TODO: get the built-info directory ready for DEPRECATION
 fs.writeFileSync("../docs/built-info/viewer.json", viewer_json) -- old
 fs.writeFileSync("../docs/api/mini.json", viewer_json)
 


### PR DESCRIPTION
Updated the documentation parser to take into consideration the fact that admonitions CAN and will have new lines (like getrunningscripts does in their docs), therefore the logic now assumes that an admonition ends if it is non-indented and a blank line instead of just assuming that any "blank" line is the end of the admonition

Also removed writing of `full.json` to the `built-info` directory to ease in deprecation, however `viewer.json` has been kept as the current sUNC results UI depends on this.