### PR TITLE
Forgot to include all the common HTTP methods

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,10 @@
 {
   "recommendations": [
     "redhat.vscode-yaml",
+
+    "JohnnyMorganz.luau-lsp",
+
     "DavidAnson.vscode-markdownlint",
-    "JohnnyMorganz.luau-lsp"
+    "yzhang.markdown-all-in-one"
   ]
 }

--- a/docs/Miscellaneous/request.md
+++ b/docs/Miscellaneous/request.md
@@ -26,29 +26,29 @@ function request(options: RequestOptions): Response
 
 ## Parameters
 
-| Parameter         | Description                                 |
-|-------------------|---------------------------------------------|
-| `#!luau options`   | A table of fields defining the HTTP request. |
+| Parameter        | Description                                  |
+| ---------------- | -------------------------------------------- |
+| `#!luau options` | A table of fields defining the HTTP request. |
 
 ### `#!luau RequestOptions` Fields
 
-| Field         | Type         | Description                                                |
-|---------------|--------------|------------------------------------------------------------|
-| `#!luau Url`     | `string`     | The target URL.                                             |
-| `#!luau Method`  | `string`     | The HTTP [method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods) (`GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `OPTIONS` or `PATCH`).         |
-| `#!luau Body`    | `string?`    | (Optional) The request payload.                             |
-| `#!luau Headers` | `{ [string]: string }?`     | (Optional) Dictionary of HTTP [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers).                      |
-| `#!luau Cookies` | `{ [string]: string }?`     | (Optional) Dictionary of [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cookie).                           |
+| Field            | Type                    | Description                                                                                                                                            |
+| ---------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `#!luau Url`     | `string`                | The target URL.                                                                                                                                        |
+| `#!luau Method`  | `string`                | The HTTP [method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods) (`GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `OPTIONS` or `PATCH`). |
+| `#!luau Body`    | `string?`               | (Optional) The request payload.                                                                                                                        |
+| `#!luau Headers` | `{ [string]: string }?` | (Optional) Dictionary of HTTP [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers).                                          |
+| `#!luau Cookies` | `{ [string]: string }?` | (Optional) Dictionary of [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cookie).                                        |
 
 ### `#!luau Response` Fields
 
-| Field              | Type       | Description                              |
-|--------------------|------------|------------------------------------------|
-| `#!luau Success`       | `boolean`          | Whether the request was successful.                                                        |
-| `#!luau Body`          | `string`           | The returned response body.                                                                |
-| `#!luau StatusCode`    | `number`           | The numeric HTTP [status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status).   |
-| `#!luau StatusMessage` | `string`           | The human-readable status description.                                                     |
-| `#!luau Headers`       | `{ [string]: string }`    | Dictionary of response [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers).|
+| Field                  | Type                   | Description                                                                                            |
+| ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `#!luau Success`       | `boolean`              | Whether the request was successful.                                                                    |
+| `#!luau Body`          | `string`               | The returned response body.                                                                            |
+| `#!luau StatusCode`    | `number`               | The numeric HTTP [status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status).    |
+| `#!luau StatusMessage` | `string`               | The human-readable status description.                                                                 |
+| `#!luau Headers`       | `{ [string]: string }` | Dictionary of response [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers). |
 
 ### Automatically added Headers
 
@@ -57,11 +57,11 @@ Executors will attach this unique header automatically:
 <!-- recommendation: standardise headers to be X-User-Identifier and X-Fingerprint -->
 <!-- the 'X' prefix is standard for custom HTTP headers, as defined in RFC822 (https://datatracker.ietf.org/doc/html/rfc822) -->
 
-| Header                     | Description                                                                 |
-|----------------------------|-----------------------------------------------------------------------------|
-| `PREFIX-User-Identifier`   | Unique user ID that stays consistent across devices for the same user.     |
-| `PREFIX-Fingerprint`       | Hardware-bound identifier (HWID) of the client's machine.                           |
-| [`User-Agent`](https://en.wikipedia.org/wiki/User-Agent_header)           | Executor name and version string.                                          |
+| Header                                                          | Description                                                            |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `PREFIX-User-Identifier`                                        | Unique user ID that stays consistent across devices for the same user. |
+| `PREFIX-Fingerprint`                                            | Hardware-bound identifier (HWID) of the client's machine.              |
+| [`User-Agent`](https://en.wikipedia.org/wiki/User-Agent_header) | Executor name and version string.                                      |
 
 ---
 

--- a/docs/Miscellaneous/request.md
+++ b/docs/Miscellaneous/request.md
@@ -2,20 +2,22 @@
 
 `#!luau request` sends a [HTTP request](https://en.wikipedia.org/wiki/HTTP) to the given URL using the provided configuration table. It yields until the request is complete and returns a structured response.
 
+<!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods -->
+
 ```luau
 type RequestOptions = {
     Url: string,
-    Method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
+    Method: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "OPTIONS" | "PATCH",
     Body: string?,
     Headers: { [string]: string }?,
     Cookies: { [string]: string }?
 }
 
 type Response = {
+    Success: boolean,
     Body: string,
     StatusCode: number,
     StatusMessage: string,
-    Success: boolean,
     Headers: { [string]: string }
 }
 
@@ -33,20 +35,20 @@ function request(options: RequestOptions): Response
 | Field         | Type         | Description                                                |
 |---------------|--------------|------------------------------------------------------------|
 | `#!luau Url`     | `string`     | The target URL.                                             |
-| `#!luau Method`  | `string`     | The HTTP [method](https://en.wikipedia.org/wiki/HTTP#Request_methods) (`GET`, `POST`, `PATCH`, or `PUT`).         |
+| `#!luau Method`  | `string`     | The HTTP [method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods) (`GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `OPTIONS` or `PATCH`).         |
 | `#!luau Body`    | `string?`    | (Optional) The request payload.                             |
-| `#!luau Headers` | `{ [string]: string }?`     | (Optional) Dictionary of HTTP [headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields).                      |
-| `#!luau Cookies` | `{ [string]: string }?`     | (Optional) Dictionary of [cookies](https://en.wikipedia.org/wiki/HTTP_cookie).                           |
+| `#!luau Headers` | `{ [string]: string }?`     | (Optional) Dictionary of HTTP [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers).                      |
+| `#!luau Cookies` | `{ [string]: string }?`     | (Optional) Dictionary of [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cookie).                           |
 
 ### `#!luau Response` Fields
 
 | Field              | Type       | Description                              |
 |--------------------|------------|------------------------------------------|
-| `#!luau Body`          | `string`           | The returned response body.                                                                |
-| `#!luau StatusCode`    | `number`           | The numeric HTTP [status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes).   |
-| `#!luau StatusMessage` | `string`           | The human-readable status description.                                                     |
 | `#!luau Success`       | `boolean`          | Whether the request was successful.                                                        |
-| `#!luau Headers`       | `{ [string]: string }`    | Dictionary of response [headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields).|
+| `#!luau Body`          | `string`           | The returned response body.                                                                |
+| `#!luau StatusCode`    | `number`           | The numeric HTTP [status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status).   |
+| `#!luau StatusMessage` | `string`           | The human-readable status description.                                                     |
+| `#!luau Headers`       | `{ [string]: string }`    | Dictionary of response [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers).|
 
 ### Automatically added Headers
 


### PR DESCRIPTION
Whilst writing the original documentation for `request`, I forgot to include all the actual valid methods. Looking back at this now, its funny I didn't include `DELETE` or `HEAD` if I included `PUT` lol.

- Fixed the mistake of not including all the proper HTTP Methods. Specifically, the `CONNECT` method is excluded because it is related to HTTP proxies rather than regular requests, and same with `TRACE` as performing a loopback  is not relevant for users nor does it yield any consumable data
- Changed wikipedia links to MDN Web documentation since they are more suited to the subject of this function (and provide more technical information than wikipedia)
- Simply changed the order of the Response fields, putting `Success` _first_ to highlight its significance