### PR TITLE
Add Warning to Base64Encode

### DIFF
--- a/docs/Cryptography/base64encode.md
+++ b/docs/Cryptography/base64encode.md
@@ -1,5 +1,10 @@
 # `crypt.base64encode`
 
+
+!!! warning "Prevent line breaks in Base64 encoded output"
+
+    Base64 encoding should not insert any `line breaks` the output must be one `continuous line`.
+
 `#!luau crypt.base64encode` encodes a string with [Base64](https://en.wikipedia.org/wiki/Base64) encoding.
 
 ```luau


### PR DESCRIPTION
I had this issue at gethiddenproperty where it didn't pass because of this