### PR TITLE
Add privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,89 @@
+# Privacy Policy for sUNC
+
+**Effective Date:** October 14, 2025  
+**Last Updated:** October 14, 2025
+
+## 1. Introduction
+
+This Privacy Policy describes how senS' Unified Naming Convention (sUNC) testing environment collects, uses, and protects your information when you use our Roblox executor environment naming convention and testing services.
+
+By using sUNC, you acknowledge that you have read and understood this Privacy Policy and consent to the data collection practices described herein.
+
+## 2. Information We Collect
+
+sUNC automatically collects the following information when you use our testing environment:
+
+### 2.1 Roblox Account Information
+- **Roblox Username:** Your publicly visible Roblox username
+- **Avatar Profile Picture:** Your publicly visible Roblox avatar's profile picture
+
+### 2.2 Technical Information
+- **Developer Console Output:** Logs and output from the Roblox developer console during testing
+- **Executor Name:** The name of the executor you're using, obtained from the User-Agent header in the `request` function
+- **User Platform:** Information about your operating system and device type that is publicly available to games you visit on the Roblox platform
+
+### 2.3 Location Information
+- **User Continent:** Your approximate geographic location at the continent level, derived from your IP address
+
+**Note:** We do not collect your full IP address, precise location, or any personally identifiable information beyond what is listed above
+
+## 3. How We Use Your Information
+
+We collect and use this information solely for the following purposes:
+
+- To analyze executor compatibility and functionality across Roblox environments
+- To identify and fix issues within the sUNC testing framework or the executor itself
+- To generate and publicly display anonymized test results for transparency and research purposes
+- To improve the accuracy and efficiency of the sUNC testing environment
+
+## 4. Data Sharing and Public Test Results
+
+sUNC uses **[sunc.rubis.app](https://sunc.rubis.app)**, a service hosted under **Rubis** ([rubis.app](https://rubis.app)), to **publicly share test results**. Rubis’ data handling practices are governed by their [Privacy Policy](https://rubis.app/privacy.html).
+
+The following data may be shared publicly via **sunc.rubis.app** after a test completes:
+
+1. **Test Results:** Which functions passed or failed the test, including error messages for failed functions
+2. **Total sUNC Score and Percentage:** The aggregate score and success rate of the test
+3. **Execution Time:** The total time taken to complete the test
+4. **sUNC Version:** The version of the testing environment used
+5. **Executor Name:** The executor identifier detected during testing
+6. **Date of Test:** The date and time when the test was conducted
+
+## 5. Data Storage and Security
+
+- All collected data is stored securely and protected against unauthorized access
+- We implement industry-standard security measures to safeguard your information
+- Data is retained only as long as necessary for testing and analysis purposes
+
+## 6. Your Rights
+
+You have the right to:
+
+- Request information about what data we have collected about you
+- Request deletion of your data from our systems
+- Opt out of data collection by discontinuing use of sUNC
+
+## 7. Third-Party Services
+
+sUNC interacts with Roblox services to function properly. Please review Roblox's Privacy Policy for information about how Roblox handles your data.
+
+We are not affiliated with, endorsed by, or officially connected to Roblox Corporation.
+
+## 8. Children's Privacy
+
+sUNC is not intended for users under the age of 13. We do not knowingly collect information from children under 13. If you believe we have collected information from a child under 13, please contact us immediately.
+
+## 9. Changes to This Privacy Policy
+
+We may update this Privacy Policy from time to time. Changes will be posted with an updated "Last Updated" date. Continued use of sUNC after changes constitutes acceptance of the updated policy.
+
+## 10. Disclaimer
+
+**IMPORTANT:** The use of Roblox executors may violate Roblox's Terms of Service. sUNC is provided for educational and testing purposes only. We are not responsible for any consequences resulting from the use of executors or our testing environment, including but not limited to account termination or other penalties imposed by Roblox.
+
+## 11. Contact Information
+
+If you have questions, concerns, or requests regarding this Privacy Policy or your data, please contact us at:
+
+[Email: hello@richy.lol](mailto:hello@richy.lol)
+[Github Issues](https://github.com/sUNC-Utilities/docs.sunc.su/issues)


### PR DESCRIPTION
I noticed that no privacy policy is specified for the sUNC executor test thanks to this message by Gelatek (a.k.a. "tac")
<img width="564" height="416" alt="image" src="https://github.com/user-attachments/assets/cd117546-0e8f-433b-9b16-6db1d4ab0447" />