### PR TITLE
Temporary parsing solution for base64xyz

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,3 +31,4 @@ This to-do list is split up into sections with tasks assigned to documentation m
 - `debug.getinfo`
   - <https://github.com/unified-naming-convention/NamingStandard/blob/305c31e4f469c056812c9f412c9a4d78293021bc/api/debug.md?plain=1#L70-L112>
   - <https://synapsexdocs.github.io/libraries/debug/#get-info>
+- Modify the documentation parser to ignore HTML comments in markdown (so that comments / todo notes dont have to be moved to the very bottom of a markdown file)

--- a/docs/Encoding/base64decode.md
+++ b/docs/Encoding/base64decode.md
@@ -1,7 +1,5 @@
 # `base64decode`
 
-<!-- TODO: in the future, make a note that hopefully we should explicitly check for ONLY base64xyz, rather than base64_xyz or crypt.xyz -->
-
 `#!luau base64decode` decodes a [Base64-encoded](https://en.wikipedia.org/wiki/Base64) string back into its original form.
 
 ```luau
@@ -22,3 +20,5 @@ function base64decode(data: string): string
 local bytecode = game:HttpGet("https://api.rubis.app/v2/scrap/zuxQZuM9Tnl5MRbo/raw")
 writefile("sound.mp3", base64decode(bytecode)) -- This file should be a valid and working MP3 file.
 ```
+
+<!-- TODO: in the future, make a note that hopefully we should explicitly check for ONLY base64xyz, rather than base64_xyz or crypt.xyz -->

--- a/docs/Encoding/base64encode.md
+++ b/docs/Encoding/base64encode.md
@@ -1,7 +1,5 @@
 # `base64encode`
 
-<!-- TODO: in the future, make a note that hopefully we should explicitly check for ONLY base64xyz, rather than base64_xyz or crypt.xyz -->
-
 `#!luau base64encode` encodes a string with [Base64](https://en.wikipedia.org/wiki/Base64) encoding.
 
 ```luau
@@ -21,3 +19,5 @@ function base64encode(data: string): string
 ```luau title="Encoding a string with Base64" linenums="1"
 print(base64encode("DummyString\0\2")) -- Output: RHVtbXlTdHJpbmcAAg==
 ```
+
+<!-- TODO: in the future, make a note that hopefully we should explicitly check for ONLY base64xyz, rather than base64_xyz or crypt.xyz -->


### PR DESCRIPTION
- Temporarily moved markdown comments to the bottom of the base64 documents so that we have functioning parsing
- Added a note to the TODO, stating that I should make the parser ignore comments in the future