### PR TITLE
Correct example as getfenv ≠ getgenv

### DIFF
--- a/docs/Environment/getgenv.md
+++ b/docs/Environment/getgenv.md
@@ -26,7 +26,7 @@ function getgenv(): { any }
 getgenv().dummy_val = "value"
 getfenv().dummy_val_2 = 1
 
-print(dummy_val, getgenv().dummy_val_2) -- Output: value, 1
+print(dummy_val, getgenv().dummy_val_2) -- Output: value, nil
 
 getgenv().dummy_val = "value2"
 dummy_val = nil


### PR DESCRIPTION
Corrected the example in getgenv to show that getfenv and getgenv are not the same environment, and therefore `dummy_val_2` must be nil in getgenv