### PR TITLE
outdated information & fixes

### DIFF
--- a/docs/Instances/cloneref.md
+++ b/docs/Instances/cloneref.md
@@ -4,9 +4,12 @@
 
     `#!luau cloneref` returns a reference to an [`#!luau Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance). This can help avoid weak table styled detections. 
 
-`#!luau cloneref` returns a **reference clone** of an [`#!luau Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance). The returned object behaves identically to the original but is not strictly equal (`==`) to it.
+!!! info "note on `#!luau cloneref` common use."
 
-This is commonly used to safely interact with services such as [`#!luau game.CoreGui`](https://create.roblox.com/docs/reference/engine/classes/Players#LocalPlayer), making weak-table style attacks fail.
+    This **was** commonly used to safely interact with specific services such as [`#!luau game.CoreGui`](https://create.roblox.com/docs/reference/engine/classes/CoreGui) but since Roblox made it so developers can't even reference/obtain said services (e.g.. `#!luau game.CoreGui` - `#!luau game:GetService("CoreGui")` all now return nil now)
+    There's now no point of using this function on **internal services** that require a specific [thread-id/capability](https://github.com/Pseudoreality/Roblox-Identities/) for developers to access. note that this doesn't mean the function is useless it's still useful for protected instances or non-internal services that still get targeted such as [`#!luau UserInputService`](https://create.roblox.com/docs/reference/engine/classes/UserInputService).
+
+`#!luau cloneref` returns a **reference clone** of an [`#!luau Instance`](https://create.roblox.com/docs/reference/engine/classes/Instance). The returned object behaves identically to the original but is not strictly equal (`==`) to it.
 
 ```luau
 function cloneref<T>(object: T & Instance): T

--- a/docs/Reflection/getthreadidentity.md
+++ b/docs/Reflection/getthreadidentity.md
@@ -1,6 +1,6 @@
 # `getthreadidentity`
 
-`#!luau getthreadidentity` retrieves the thread's identity of the running [Luau thread](https://create.roblox.com/docs/reference/engine/libraries/coroutine#running).
+`#!luau getthreadidentity` retrieves the [thread's identity](https://github.com/Pseudoreality/Roblox-Identities/tree/main/Identities) of the running [Luau thread](https://create.roblox.com/docs/reference/engine/libraries/coroutine#running).
 
 ```luau
 function getthreadidentity(): number

--- a/docs/Reflection/setthreadidentity.md
+++ b/docs/Reflection/setthreadidentity.md
@@ -1,8 +1,14 @@
 # `setthreadidentity`
 
-`#!luau setthreadidentity` sets the current [Luau thread](https://create.roblox.com/docs/reference/engine/libraries/coroutine#running) identity and capabilities matching that identity.
+!!! info "Not all locked functions can be called"
+
+    Some functions like `#!luau debug.dumpheap()`, `#!luau debug.dumprefs()`, or other similar debug functions strictly require the calling thread to be `CommandBar` to be called.
+    So just changing your thread's id to `4` (CommandBar Id) will mostly not work.
+
+`#!luau setthreadidentity` sets the current [Luau thread](https://create.roblox.com/docs/reference/engine/libraries/coroutine#running) [identity and capabilities](https://github.com/Pseudoreality/Roblox-Identities/) matching that identity.
 
 This is commonly used alongside functions like [`#!luau gethiddenproperty`](./gethiddenproperty.md) or [`#!luau getconnections`](../Signals/getconnections.md) which may require elevated access.
+or maybe used to obtain engine features like specific propeties, methods, intances, that are locked behind specific capabilities that level 7 or 8 don't have such as [InternalTest](https://github.com/Pseudoreality/Roblox-Identities/blob/main/Capabilities/60%20-%20InternalTest.md).
 
 ```luau
 function setthreadidentity(id: number): ()
@@ -12,16 +18,44 @@ function setthreadidentity(id: number): ()
 
 | Parameter   | Description                                      |
 | ----------- | ------------------------------------------------ |
-| `#!luau id` | The identity level to set the current thread to. |
+| `#!luau id` | The [identity level](https://github.com/Pseudoreality/Roblox-Identities/tree/main/Identities) to set the current thread to. |
 
 ---
 
 ## Example
 
-```luau title="Changing thread identity for privileged access" linenums="1"
+```luau title="Changing thread identity to obtain CoreGui" linenums="1"
+local function GetCoreGui()
+	if game:GetService("CoreGui") then
+		return true, game:FindService("CoreGui")
+	end
+	return false, nil
+end
+
 setthreadidentity(2)
-print(pcall(function() return game.CoreGui end)) -- Output: false (restricted access)
+print(GetCoreGui()) -- false, nil
 
 setthreadidentity(8)
-print(pcall(function() return game.CoreGui end)) -- Output: true Instance
+print(GetCoreGui()) -- true, CoreGui
+```
+
+## Example 2
+
+```luau title="Changing thread identity for features not available for 7 or 8" linenums="1"
+local RunService = game.RunService
+local function FrameNumber()
+	local success, frame = pcall(function()
+		return RunService.FrameNumber
+	end)
+	if success then
+		return success, type(frame)
+	end
+	return false, frame
+end
+
+print(getthreadidentity()) -- 7 or 8
+print(FrameNumber()) -- false, The current thread cannot read 'FrameNumber' (lacking capability InternalTest)
+
+setthreadidentity(3)
+print(FrameNumber()) -- true, number
 ```


### PR DESCRIPTION
- outdated `common use` for `cloneref` (also for some reason `game.CoreGui` let to the `Players.LocalPlayer` doc instead of the actual CoreGui doc??)

- added links to `getthreadidentity` about roblox identitys & capabilities

- added extra information to `setthreadidentity` (there was a broken example that didn't work and added another one)

```Luau
setthreadidentity(2)
print(pcall(function() return game.CoreGui end)) -- Output: false (restricted access)
-- this doesn't error anymore. so output is: true, nil - to know why read cloneref

setthreadidentity(8)
print(pcall(function() return game.CoreGui end)) -- Output: true Instance
```